### PR TITLE
docs(readme): surface basecamp and full capabilities in the overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # logos-scaffold
 
 `logos-scaffold` is a Rust CLI that takes a LEZ (Logos Execution Zone)
-program from an empty directory all the way to a deployed, transacting app
-(think Anchor for Solana, but for Logos). It scaffolds the project, runs a
-local chain, builds and deploys your program, then runs it inside
-**basecamp** (the Logos desktop app) across multiple peer profiles so you
-can dogfood real multi-peer behavior. One tool for the full inner loop.
+program from an empty directory all the way to a deployed, transacting app.
+It scaffolds the project, runs a local chain, builds and deploys your
+program, then runs it inside **basecamp** (the Logos desktop app) across
+multiple peer profiles so you can dogfood real multi-peer behavior. One tool
+for the full inner loop.
 
 ## What it does for you
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
 # logos-scaffold
 
 `logos-scaffold` is a Rust CLI that takes a LEZ (Logos Execution Zone)
-program from an empty directory all the way to a deployed, transacting app —
-think Anchor for Solana, but for Logos. It scaffolds the project, runs a
-local chain, builds and deploys your program, and then runs it inside
+program from an empty directory all the way to a deployed, transacting app
+(think Anchor for Solana, but for Logos). It scaffolds the project, runs a
+local chain, builds and deploys your program, then runs it inside
 **basecamp** (the Logos desktop app) across multiple peer profiles so you
 can dogfood real multi-peer behavior. One tool for the full inner loop.
 
 ## What it does for you
 
-- **Start a project** — `create`/`new` scaffolds a complete LEZ
+- **Start a project:** `create`/`new` scaffolds a complete LEZ
   `program_deployment` project; `init` adopts scaffold into an existing one.
-- **Set up dependencies** — `setup` builds the pinned sequencer, wallet, and
+- **Set up dependencies:** `setup` builds the pinned sequencer, wallet, and
   `spel` toolchain locally: no global installs, portable across machines and CI.
-- **Run a local chain** — `localnet` starts, stops, inspects, and resets a
+- **Run a local chain:** `localnet` starts, stops, inspects, and resets a
   local sequencer to deploy against.
-- **Build and deploy** — `build` compiles the workspace and guest programs;
+- **Build and deploy:** `build` compiles the workspace and guest programs;
   `deploy` ships them to localnet and reports the on-chain program ID.
-- **Manage wallets** — `wallet` lists accounts, sets a project default, and
+- **Manage wallets:** `wallet` lists accounts, sets a project default, and
   tops up from the faucet.
-- **One-shot inner loop** — `run` chains build → deploy → post-deploy hooks,
+- **One-shot inner loop:** `run` chains build, deploy, and post-deploy hooks,
   with `--watch` to re-run on file changes.
-- **Peer-to-peer dogfooding** — `basecamp` runs your program inside basecamp,
-  the Logos desktop app, across pre-seeded peer profiles (alice and bob): it
+- **Peer-to-peer dogfooding:** `basecamp` runs your program inside basecamp,
+  the Logos desktop app, across pre-seeded peer profiles (alice and bob). It
   builds basecamp, packages your program as an installable module, installs it
-  per profile, and launches each with clean-slate state — so you test real
-  multi-peer behavior, not a single node in isolation.
-- **Diagnose** — `doctor` runs health checks; `report` bundles a sanitized
+  per profile, and launches each with clean-slate state, so you test real
+  multi-peer behavior instead of a single node in isolation.
+- **Diagnose:** `doctor` runs health checks; `report` bundles a sanitized
   diagnostics archive for issues.
 
 See [Command Semantics](#command-semantics) below for the full reference.
@@ -35,7 +35,7 @@ See [Command Semantics](#command-semantics) below for the full reference.
 
 - Unix-only (localnet and process/port detection use `lsof`, `ps`, `kill`).
 - Single external dependency: [LEZ](https://github.com/logos-blockchain/logos-execution-zone/); standalone sequencer flow only, no `logos-blockchain` dependency.
-- Reference docs: [FURPS+](FURPS.md) (requirements) · [ADR](ADR.md) (decisions).
+- Reference docs: [FURPS+](FURPS.md) (requirements), [ADR](ADR.md) (decisions).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # logos-scaffold
 
-`logos-scaffold` is a Rust CLI for bootstrapping LEZ (Logos Execution Zone) `program_deployment` projects in standalone mode.
+`logos-scaffold` is a Rust CLI that takes a LEZ (Logos Execution Zone)
+program from an empty directory all the way to running across a network of
+peers — think Anchor for Solana, but for Logos. It is the single tool a
+developer needs for the full inner loop.
+
+## What it does for you
+
+- **Start a project from scratch.** `create`/`new` scaffolds a complete
+  LEZ `program_deployment` project (or adopt scaffold in an existing one
+  with `init`), so you write program logic instead of boilerplate.
+- **Set up every dependency for you.** `setup` fetches and builds the
+  pinned sequencer, wallet, and `spel` toolchain locally — no global
+  installs, no version drift, portable across machines and CI.
+- **Run a blockchain on your laptop.** `localnet` starts, stops, inspects,
+  and resets a local sequencer so you have a real chain to deploy against
+  in seconds.
+- **Build and deploy your program.** `build` compiles the workspace and
+  guest programs; `deploy` ships them to the running localnet and reports
+  the on-chain program ID.
+- **Manage wallets and test funds.** `wallet` lists accounts, sets a
+  project default, and tops up from the faucet so you always have a funded
+  account to transact with.
+- **Do it all in one command.** `run` chains build → IDL → localnet →
+  topup → deploy → your post-deploy hooks, with an optional `--watch` mode
+  that re-runs on every file change.
+- **Test peer-to-peer in the real app.** `basecamp` lets you run your
+  program inside basecamp, the Logos desktop application, across multiple
+  pre-seeded peer profiles (alice and bob). It fetches and builds basecamp,
+  packages your program as an installable module, installs it into each
+  peer's profile, and launches them with clean-slate, isolated state — so
+  you can dogfood actual multi-peer behavior end to end instead of testing
+  a single node in isolation.
+- **Diagnose and report.** `doctor` runs actionable health checks and
+  `report` bundles a sanitized diagnostics archive for filing issues.
+
+Everything below documents these capabilities in detail.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # logos-scaffold
 
 `logos-scaffold` is a Rust CLI that takes a LEZ (Logos Execution Zone)
-program from an empty directory all the way to running across a network of
-peers — think Anchor for Solana, but for Logos. It is the single tool a
-developer needs for the full inner loop.
+program from an empty directory all the way to a deployed, transacting app —
+think Anchor for Solana, but for Logos. It scaffolds the project, runs a
+local chain, builds and deploys your program, and then runs it inside
+**basecamp** (the Logos desktop app) across multiple peer profiles so you
+can dogfood real multi-peer behavior. One tool for the full inner loop.
 
 ## What it does for you
 

--- a/README.md
+++ b/README.md
@@ -7,51 +7,33 @@ developer needs for the full inner loop.
 
 ## What it does for you
 
-- **Start a project from scratch.** `create`/`new` scaffolds a complete
-  LEZ `program_deployment` project (or adopt scaffold in an existing one
-  with `init`), so you write program logic instead of boilerplate.
-- **Set up every dependency for you.** `setup` fetches and builds the
-  pinned sequencer, wallet, and `spel` toolchain locally — no global
-  installs, no version drift, portable across machines and CI.
-- **Run a blockchain on your laptop.** `localnet` starts, stops, inspects,
-  and resets a local sequencer so you have a real chain to deploy against
-  in seconds.
-- **Build and deploy your program.** `build` compiles the workspace and
-  guest programs; `deploy` ships them to the running localnet and reports
-  the on-chain program ID.
-- **Manage wallets and test funds.** `wallet` lists accounts, sets a
-  project default, and tops up from the faucet so you always have a funded
-  account to transact with.
-- **Do it all in one command.** `run` chains build → IDL → localnet →
-  topup → deploy → your post-deploy hooks, with an optional `--watch` mode
-  that re-runs on every file change.
-- **Test peer-to-peer in the real app.** `basecamp` lets you run your
-  program inside basecamp, the Logos desktop application, across multiple
-  pre-seeded peer profiles (alice and bob). It fetches and builds basecamp,
-  packages your program as an installable module, installs it into each
-  peer's profile, and launches them with clean-slate, isolated state — so
-  you can dogfood actual multi-peer behavior end to end instead of testing
-  a single node in isolation.
-- **Diagnose and report.** `doctor` runs actionable health checks and
-  `report` bundles a sanitized diagnostics archive for filing issues.
+- **Start a project** — `create`/`new` scaffolds a complete LEZ
+  `program_deployment` project; `init` adopts scaffold into an existing one.
+- **Set up dependencies** — `setup` builds the pinned sequencer, wallet, and
+  `spel` toolchain locally: no global installs, portable across machines and CI.
+- **Run a local chain** — `localnet` starts, stops, inspects, and resets a
+  local sequencer to deploy against.
+- **Build and deploy** — `build` compiles the workspace and guest programs;
+  `deploy` ships them to localnet and reports the on-chain program ID.
+- **Manage wallets** — `wallet` lists accounts, sets a project default, and
+  tops up from the faucet.
+- **One-shot inner loop** — `run` chains build → deploy → post-deploy hooks,
+  with `--watch` to re-run on file changes.
+- **Peer-to-peer dogfooding** — `basecamp` runs your program inside basecamp,
+  the Logos desktop app, across pre-seeded peer profiles (alice and bob): it
+  builds basecamp, packages your program as an installable module, installs it
+  per profile, and launches each with clean-slate state — so you test real
+  multi-peer behavior, not a single node in isolation.
+- **Diagnose** — `doctor` runs health checks; `report` bundles a sanitized
+  diagnostics archive for issues.
 
-Everything below documents these capabilities in detail.
+See [Command Semantics](#command-semantics) below for the full reference.
 
-## Documentation
+## Scope & platform
 
-- [FURPS+](FURPS.md) — Functional and non-functional requirements
-- [ADR](ADR.md) — Architecture Decision Records
-
-## Platform
-
-The CLI is currently Unix-only.
-Localnet and process/port detection rely on Unix tools (lsof, ps, kill).
-
-## Scope
-
-- Single external dependency: [LEZ](https://github.com/logos-blockchain/logos-execution-zone/)
-- Standalone sequencer flow only
-- No `logos-blockchain` dependency
+- Unix-only (localnet and process/port detection use `lsof`, `ps`, `kill`).
+- Single external dependency: [LEZ](https://github.com/logos-blockchain/logos-execution-zone/); standalone sequencer flow only, no `logos-blockchain` dependency.
+- Reference docs: [FURPS+](FURPS.md) (requirements) · [ADR](ADR.md) (decisions).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Why

The README opened by saying the tool only bootstraps LEZ `program_deployment` projects. Readers (humans and agents alike) consistently missed the **`basecamp`** subcommand: its capabilities were buried in the *Command Semantics* section with no mention up top. The opening paragraph also miscredited the "Anchor for Solana" analogy, which belongs to spel and the LEZ Framework, not to scaffold.

## What changed

All changes are in `README.md` (overview only; the detailed `## CLI` and `## Command Semantics` sections are untouched).

1. **Rewrote the opening paragraph** to state the full arc: scaffold the project, run a local chain, build and deploy, then run inside **basecamp** (the Logos desktop app) across peer profiles for multi-peer dogfooding. basecamp is now named in the first sentence. Dropped the "Anchor for Solana" framing (that's spel's / the LEZ Framework's identity, and it already appears correctly further down).

2. **Added a "What it does for you" section** that translates each command group into plain English:
   - `create`/`new`/`init`: start a project from scratch
   - `setup`: build all dependencies (sequencer, wallet, spel) locally
   - `localnet`: run a local chain
   - `build`/`deploy`: build and deploy your program
   - `wallet`: manage wallets and test funds
   - `run`: one-shot inner loop (+ `--watch`)
   - **`basecamp`: run your program inside basecamp across pre-seeded alice/bob peer profiles with clean-slate state, for real multi-peer dogfooding**
   - `doctor`/`report`: diagnose and report

3. **Merged three stub sections** (`Documentation`, `Platform`, `Scope`) into one `Scope & platform` block.

4. **Cleaned the prose** (removed em-dashes and other AI writing tells).

Net: the overview is shorter than before the change despite adding the capability summary.