### PR TITLE
fix(ci): unbreak master — format spawn_to_log stdio chain

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -632,7 +632,9 @@ pub(crate) fn spawn_to_log(cmd: &mut Command, log_path: &Path) -> DynResult<u32>
     }
     let file = File::create(log_path)?;
     let err_file = file.try_clone()?;
-    cmd.stdin(Stdio::null()).stdout(Stdio::from(file)).stderr(Stdio::from(err_file));
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::from(file))
+        .stderr(Stdio::from(err_file));
 
     // Daemonize: detach from parent process group so the sequencer
     // survives shell/tmux session closure


### PR DESCRIPTION
## Problem

CI on `master` is red: [run 32425458544](https://github.com/logos-co/scaffold/actions/runs/32425458544/job/96606374872) (and the run before it, 32425417470) fail at the **Check formatting** step, which aborts `validate` before **Build check** and **Run tests** ever execute.

```
Diff in /home/runner/work/scaffold/scaffold/src/process.rs:632:
-    cmd.stdin(Stdio::null()).stdout(Stdio::from(file)).stderr(Stdio::from(err_file));
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::from(file))
+        .stderr(Stdio::from(err_file));
```

The line landed with the setsid daemonize change (#34): the `stdin/stdout/stderr` builder chain in `spawn_to_log` was written on a single line that exceeds rustfmt's max width.

## Fix

Ran `cargo fmt`. Single hunk, no behaviour change.

## Verification

All three CI steps run clean locally against this branch:

- `cargo fmt --check` — clean
- `cargo check` — passes (2 pre-existing `unexpected_cfg` warnings for `feature = "sha2"`, unrelated)
- `cargo test` — 752 passed, 0 failed (562 unit + 182 CLI + 3 testnode API + 5 doc-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)