### PR TITLE
fix: two defects found running the DOGFOODING runbook end-to-end

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -87,7 +87,7 @@ fn cmd_new_inner(cmd: &NewCommand, target: &Path, template_variant: &str) -> Dyn
     fs::create_dir_all(target.join(".scaffold/state"))?;
     fs::create_dir_all(target.join(".scaffold/logs"))?;
 
-    let (bootstrap_cache, _) = bootstrap_cache_root(cmd.cache_root.as_deref())?;
+    let bootstrap_cache = bootstrap_cache_root(cmd.cache_root.as_deref())?;
     fs::create_dir_all(bootstrap_cache.join("repos"))?;
     fs::create_dir_all(bootstrap_cache.join("state"))?;
     fs::create_dir_all(bootstrap_cache.join("logs"))?;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -14,7 +14,7 @@ use crate::constants::{
     FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
-use crate::project::default_cache_root;
+use crate::project::bootstrap_cache_root;
 use crate::repo::{sync_repo_to_pin_at_path_with_opts, RepoSyncOptions};
 use crate::state::write_text;
 use crate::template::copy::{copy_dir_contents, patch_simple_tail_call_program_id};
@@ -87,13 +87,7 @@ fn cmd_new_inner(cmd: &NewCommand, target: &Path, template_variant: &str) -> Dyn
     fs::create_dir_all(target.join(".scaffold/state"))?;
     fs::create_dir_all(target.join(".scaffold/logs"))?;
 
-    let (bootstrap_cache, _) = match &cmd.cache_root {
-        Some(p) => (p.clone(), ()),
-        None => {
-            let (path, _) = default_cache_root()?;
-            (path, ())
-        }
-    };
+    let (bootstrap_cache, _) = bootstrap_cache_root(cmd.cache_root.as_deref())?;
     fs::create_dir_all(bootstrap_cache.join("repos"))?;
     fs::create_dir_all(bootstrap_cache.join("state"))?;
     fs::create_dir_all(bootstrap_cache.join("logs"))?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -160,20 +160,18 @@ pub(crate) fn resolve_cache_root(project: &Project) -> DynResult<(PathBuf, Cache
 /// project created under `LOGOS_SCAFFOLD_CACHE_ROOT` bootstrapped into the default
 /// cache and then resolved the env one for every later command — cloning the
 /// pinned LEZ twice and reporting a cache root that creation never used.
-pub(crate) fn bootstrap_cache_root(
-    cli_override: Option<&Path>,
-) -> DynResult<(PathBuf, CacheRootSource)> {
+pub(crate) fn bootstrap_cache_root(cli_override: Option<&Path>) -> DynResult<PathBuf> {
     if let Some(path) = cli_override {
-        return Ok((path.to_path_buf(), CacheRootSource::Config));
+        return Ok(path.to_path_buf());
     }
 
     if let Ok(val) = env::var("LOGOS_SCAFFOLD_CACHE_ROOT") {
         if !val.is_empty() {
-            return Ok((PathBuf::from(val), CacheRootSource::Env));
+            return Ok(PathBuf::from(val));
         }
     }
 
-    default_cache_root()
+    default_cache_root().map(|(path, _)| path)
 }
 
 /// Platform-default cache root when neither env nor `scaffold.toml` set one.
@@ -391,10 +389,8 @@ mod tests {
         env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "/tmp/from-env");
         let resolved = bootstrap_cache_root(None);
         env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
-        let (path, source) = resolved.expect("resolve");
 
-        assert_eq!(path, PathBuf::from("/tmp/from-env"));
-        assert_eq!(source, CacheRootSource::Env);
+        assert_eq!(resolved.expect("resolve"), PathBuf::from("/tmp/from-env"));
     }
 
     #[test]
@@ -403,9 +399,8 @@ mod tests {
         env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "/tmp/from-env");
         let resolved = bootstrap_cache_root(Some(Path::new("/tmp/from-flag")));
         env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
-        let (path, _) = resolved.expect("resolve");
 
-        assert_eq!(path, PathBuf::from("/tmp/from-flag"));
+        assert_eq!(resolved.expect("resolve"), PathBuf::from("/tmp/from-flag"));
     }
 
     #[test]
@@ -413,10 +408,10 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "");
         let resolved = bootstrap_cache_root(None);
+        let expected = default_cache_root().expect("default").0;
         env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
-        let (_, source) = resolved.expect("resolve");
 
-        assert_ne!(source, CacheRootSource::Env);
+        assert_eq!(resolved.expect("resolve"), expected);
     }
 
     #[test]

--- a/src/project.rs
+++ b/src/project.rs
@@ -149,6 +149,33 @@ pub(crate) fn resolve_cache_root(project: &Project) -> DynResult<(PathBuf, Cache
     default_cache_root()
 }
 
+/// Resolves the cache root for `create` / `new`, which run *before* a project
+/// (and therefore a `scaffold.toml`) exists. Order:
+/// 1. `--cache-root` when the caller passed one,
+/// 2. `LOGOS_SCAFFOLD_CACHE_ROOT` env var (non-empty),
+/// 3. `default_cache_root()` — XDG / HOME / platform fallback.
+///
+/// This is `resolve_cache_root` minus the `scaffold.toml` layer. Keeping the two
+/// side by side is deliberate: creation used to skip the env layer entirely, so a
+/// project created under `LOGOS_SCAFFOLD_CACHE_ROOT` bootstrapped into the default
+/// cache and then resolved the env one for every later command — cloning the
+/// pinned LEZ twice and reporting a cache root that creation never used.
+pub(crate) fn bootstrap_cache_root(
+    cli_override: Option<&Path>,
+) -> DynResult<(PathBuf, CacheRootSource)> {
+    if let Some(path) = cli_override {
+        return Ok((path.to_path_buf(), CacheRootSource::Config));
+    }
+
+    if let Ok(val) = env::var("LOGOS_SCAFFOLD_CACHE_ROOT") {
+        if !val.is_empty() {
+            return Ok((PathBuf::from(val), CacheRootSource::Env));
+        }
+    }
+
+    default_cache_root()
+}
+
 /// Platform-default cache root when neither env nor `scaffold.toml` set one.
 /// Returns the source layer alongside the path.
 pub(crate) fn default_cache_root() -> DynResult<(PathBuf, CacheRootSource)> {
@@ -352,6 +379,44 @@ mod tests {
         // both lez.path and lez.pin are empty in fixture
         let err = resolve_repo_path(&project, &project.config.lez, "lez").unwrap_err();
         assert!(err.to_string().contains("lez"), "{err}");
+    }
+
+    // Creation (`create` / `new`) has no scaffold.toml yet, so it resolves the
+    // cache root through `bootstrap_cache_root`. It previously skipped the env
+    // layer, bootstrapping into the default cache while every later command in
+    // the created project used the env one.
+    #[test]
+    fn bootstrap_env_layer_wins_when_no_cli_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "/tmp/from-env");
+        let resolved = bootstrap_cache_root(None);
+        env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
+        let (path, source) = resolved.expect("resolve");
+
+        assert_eq!(path, PathBuf::from("/tmp/from-env"));
+        assert_eq!(source, CacheRootSource::Env);
+    }
+
+    #[test]
+    fn bootstrap_cli_override_wins_over_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "/tmp/from-env");
+        let resolved = bootstrap_cache_root(Some(Path::new("/tmp/from-flag")));
+        env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
+        let (path, _) = resolved.expect("resolve");
+
+        assert_eq!(path, PathBuf::from("/tmp/from-flag"));
+    }
+
+    #[test]
+    fn bootstrap_empty_env_falls_through_to_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        env::set_var("LOGOS_SCAFFOLD_CACHE_ROOT", "");
+        let resolved = bootstrap_cache_root(None);
+        env::remove_var("LOGOS_SCAFFOLD_CACHE_ROOT");
+        let (_, source) = resolved.expect("resolve");
+
+        assert_ne!(source, CacheRootSource::Env);
     }
 
     #[test]

--- a/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
+++ b/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
@@ -20,8 +20,11 @@ mod lez_counter {
     ) -> SpelResult {
         // Start the counter at an explicit zero so `increment` always has a
         // well-formed 8-byte little-endian value to read back.
-        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec())
-            .expect("an 8-byte counter always fits in Data");
+        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec()).map_err(|_| {
+            SpelError::SerializationError {
+                message: "counter must be an 8-byte little-endian u64".to_string(),
+            }
+        })?;
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
@@ -38,15 +41,28 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
+        // `initialize` seeds exactly 8 bytes, so anything else means the account was
+        // never initialized or its layout drifted. Surface that instead of treating
+        // it as zero, which would silently restart the count and hide the corruption.
         let current = counter
             .account
             .data
             .get(..8)
             .and_then(|head| <[u8; 8]>::try_from(head).ok())
-            .map_or(0u64, u64::from_le_bytes);
+            .map(u64::from_le_bytes)
+            .ok_or(SpelError::AccountNotInitialized { account_index: 0 })?;
 
-        counter.account.data = Data::try_from(current.wrapping_add(amount).to_le_bytes().to_vec())
-            .expect("an 8-byte counter always fits in Data");
+        let next = current
+            .checked_add(amount)
+            .ok_or_else(|| SpelError::Overflow {
+                operation: format!("counter {current} + {amount}"),
+            })?;
+
+        counter.account.data = Data::try_from(next.to_le_bytes().to_vec()).map_err(|_| {
+            SpelError::SerializationError {
+                message: "counter must be an 8-byte little-endian u64".to_string(),
+            }
+        })?;
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }

--- a/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
+++ b/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
@@ -1,5 +1,6 @@
 #![no_main]
 
+use nssa_core::account::Data;
 use spel_framework::prelude::*;
 
 #[cfg(not(test))]
@@ -13,10 +14,15 @@ mod lez_counter {
     #[instruction]
     pub fn initialize(
         #[account(init, pda = literal("counter"))]
-        counter: AccountWithMetadata,
+        mut counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
     ) -> SpelResult {
+        // Start the counter at an explicit zero so `increment` always has a
+        // well-formed 8-byte little-endian value to read back.
+        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec())
+            .expect("an 8-byte counter always fits in Data");
+
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 
@@ -28,7 +34,19 @@ mod lez_counter {
         authority: AccountWithMetadata,
         amount: u64,
     ) -> SpelResult {
-        counter.account.balance += amount as u128;
+        // The counter lives in `data`, not `balance`. LEZ enforces conservation of
+        // total balance across a transaction, so `balance += amount` minted tokens
+        // and every `increment` was rejected at the execution check with
+        // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
+        let current = counter
+            .account
+            .data
+            .get(..8)
+            .and_then(|head| <[u8; 8]>::try_from(head).ok())
+            .map_or(0u64, u64::from_le_bytes);
+
+        counter.account.data = Data::try_from(current.wrapping_add(amount).to_le_bytes().to_vec())
+            .expect("an 8-byte counter always fits in Data");
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }

--- a/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
+++ b/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
@@ -41,14 +41,21 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
-        // `initialize` seeds exactly 8 bytes, so any other length means the account
-        // was never initialized or its layout drifted. Convert the whole buffer
-        // rather than its first 8 bytes: a prefix decode would accept a longer,
-        // drifted account and silently ignore the trailing bytes, and treating a
-        // short one as zero would restart the count and hide the corruption.
-        let current = <[u8; 8]>::try_from(&counter.account.data[..])
-            .map(u64::from_le_bytes)
-            .map_err(|_| SpelError::AccountNotInitialized { account_index: 0 })?;
+        // `initialize` seeds exactly 8 bytes, so any other length is a fault worth
+        // reporting rather than papering over: treating a short buffer as zero
+        // would silently restart the count. Empty means the account was never
+        // initialized, which is the likely mistake (calling `increment` first);
+        // any other length is a corrupt or drifted layout, so keep the two
+        // distinguishable. Convert the whole buffer, not its first 8 bytes — a
+        // prefix decode would accept a longer account and drop the trailing bytes.
+        let current = match &counter.account.data[..] {
+            [] => return Err(SpelError::AccountNotInitialized { account_index: 0 }),
+            bytes => <[u8; 8]>::try_from(bytes).map(u64::from_le_bytes).map_err(|_| {
+                SpelError::SerializationError {
+                    message: "counter must be an 8-byte little-endian u64".to_string(),
+                }
+            })?,
+        };
 
         let next = current
             .checked_add(amount)

--- a/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
+++ b/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
@@ -41,16 +41,14 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
-        // `initialize` seeds exactly 8 bytes, so anything else means the account was
-        // never initialized or its layout drifted. Surface that instead of treating
-        // it as zero, which would silently restart the count and hide the corruption.
-        let current = counter
-            .account
-            .data
-            .get(..8)
-            .and_then(|head| <[u8; 8]>::try_from(head).ok())
+        // `initialize` seeds exactly 8 bytes, so any other length means the account
+        // was never initialized or its layout drifted. Convert the whole buffer
+        // rather than its first 8 bytes: a prefix decode would accept a longer,
+        // drifted account and silently ignore the trailing bytes, and treating a
+        // short one as zero would restart the count and hide the corruption.
+        let current = <[u8; 8]>::try_from(&counter.account.data[..])
             .map(u64::from_le_bytes)
-            .ok_or(SpelError::AccountNotInitialized { account_index: 0 })?;
+            .map_err(|_| SpelError::AccountNotInitialized { account_index: 0 })?;
 
         let next = current
             .checked_add(amount)

--- a/templates/lez-framework/src/lib.rs
+++ b/templates/lez-framework/src/lib.rs
@@ -66,14 +66,21 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
-        // `initialize` seeds exactly 8 bytes, so any other length means the account
-        // was never initialized or its layout drifted. Convert the whole buffer
-        // rather than its first 8 bytes: a prefix decode would accept a longer,
-        // drifted account and silently ignore the trailing bytes, and treating a
-        // short one as zero would restart the count and hide the corruption.
-        let current = <[u8; 8]>::try_from(&counter.account.data[..])
-            .map(u64::from_le_bytes)
-            .map_err(|_| SpelError::AccountNotInitialized { account_index: 0 })?;
+        // `initialize` seeds exactly 8 bytes, so any other length is a fault worth
+        // reporting rather than papering over: treating a short buffer as zero
+        // would silently restart the count. Empty means the account was never
+        // initialized, which is the likely mistake (calling `increment` first);
+        // any other length is a corrupt or drifted layout, so keep the two
+        // distinguishable. Convert the whole buffer, not its first 8 bytes — a
+        // prefix decode would accept a longer account and drop the trailing bytes.
+        let current = match &counter.account.data[..] {
+            [] => return Err(SpelError::AccountNotInitialized { account_index: 0 }),
+            bytes => <[u8; 8]>::try_from(bytes).map(u64::from_le_bytes).map_err(|_| {
+                SpelError::SerializationError {
+                    message: "counter must be an 8-byte little-endian u64".to_string(),
+                }
+            })?,
+        };
 
         let next = current
             .checked_add(amount)

--- a/templates/lez-framework/src/lib.rs
+++ b/templates/lez-framework/src/lib.rs
@@ -66,16 +66,14 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
-        // `initialize` seeds exactly 8 bytes, so anything else means the account was
-        // never initialized or its layout drifted. Surface that instead of treating
-        // it as zero, which would silently restart the count and hide the corruption.
-        let current = counter
-            .account
-            .data
-            .get(..8)
-            .and_then(|head| <[u8; 8]>::try_from(head).ok())
+        // `initialize` seeds exactly 8 bytes, so any other length means the account
+        // was never initialized or its layout drifted. Convert the whole buffer
+        // rather than its first 8 bytes: a prefix decode would accept a longer,
+        // drifted account and silently ignore the trailing bytes, and treating a
+        // short one as zero would restart the count and hide the corruption.
+        let current = <[u8; 8]>::try_from(&counter.account.data[..])
             .map(u64::from_le_bytes)
-            .ok_or(SpelError::AccountNotInitialized { account_index: 0 })?;
+            .map_err(|_| SpelError::AccountNotInitialized { account_index: 0 })?;
 
         let next = current
             .checked_add(amount)

--- a/templates/lez-framework/src/lib.rs
+++ b/templates/lez-framework/src/lib.rs
@@ -27,8 +27,8 @@ pub mod runner_support {
 
 // Host-side program definition for IDL extraction and testing.
 // The guest binary (methods/guest) handles zkvm execution.
+use nssa_core::account::{AccountWithMetadata, Data};
 use spel_framework::prelude::*;
-use nssa_core::account::AccountWithMetadata;
 
 #[lez_program]
 mod lez_counter {
@@ -38,10 +38,16 @@ mod lez_counter {
     #[instruction]
     pub fn initialize(
         #[account(init, pda = literal("counter"))]
-        counter: AccountWithMetadata,
+        mut counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
     ) -> SpelResult {
+        // Keep this body in step with methods/guest/src/bin/lez_counter.rs: this
+        // copy is what `build idl` extracts the IDL from, the guest is what the
+        // sequencer executes, and they must describe the same program.
+        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec())
+            .expect("an 8-byte counter always fits in Data");
+
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 
@@ -53,7 +59,19 @@ mod lez_counter {
         authority: AccountWithMetadata,
         amount: u64,
     ) -> SpelResult {
-        counter.account.balance += amount as u128;
+        // The counter lives in `data`, not `balance`. LEZ enforces conservation of
+        // total balance across a transaction, so `balance += amount` minted tokens
+        // and every `increment` was rejected at the execution check with
+        // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
+        let current = counter
+            .account
+            .data
+            .get(..8)
+            .and_then(|head| <[u8; 8]>::try_from(head).ok())
+            .map_or(0u64, u64::from_le_bytes);
+
+        counter.account.data = Data::try_from(current.wrapping_add(amount).to_le_bytes().to_vec())
+            .expect("an 8-byte counter always fits in Data");
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }

--- a/templates/lez-framework/src/lib.rs
+++ b/templates/lez-framework/src/lib.rs
@@ -45,8 +45,11 @@ mod lez_counter {
         // Keep this body in step with methods/guest/src/bin/lez_counter.rs: this
         // copy is what `build idl` extracts the IDL from, the guest is what the
         // sequencer executes, and they must describe the same program.
-        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec())
-            .expect("an 8-byte counter always fits in Data");
+        counter.account.data = Data::try_from(0u64.to_le_bytes().to_vec()).map_err(|_| {
+            SpelError::SerializationError {
+                message: "counter must be an 8-byte little-endian u64".to_string(),
+            }
+        })?;
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
@@ -63,15 +66,28 @@ mod lez_counter {
         // total balance across a transaction, so `balance += amount` minted tokens
         // and every `increment` was rejected at the execution check with
         // `InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance …))`.
+        // `initialize` seeds exactly 8 bytes, so anything else means the account was
+        // never initialized or its layout drifted. Surface that instead of treating
+        // it as zero, which would silently restart the count and hide the corruption.
         let current = counter
             .account
             .data
             .get(..8)
             .and_then(|head| <[u8; 8]>::try_from(head).ok())
-            .map_or(0u64, u64::from_le_bytes);
+            .map(u64::from_le_bytes)
+            .ok_or(SpelError::AccountNotInitialized { account_index: 0 })?;
 
-        counter.account.data = Data::try_from(current.wrapping_add(amount).to_le_bytes().to_vec())
-            .expect("an 8-byte counter always fits in Data");
+        let next = current
+            .checked_add(amount)
+            .ok_or_else(|| SpelError::Overflow {
+                operation: format!("counter {current} + {amount}"),
+            })?;
+
+        counter.account.data = Data::try_from(next.to_le_bytes().to_vec()).map_err(|_| {
+            SpelError::SerializationError {
+                message: "counter must be an 8-byte little-endian u64".to_string(),
+            }
+        })?;
 
         Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }


### PR DESCRIPTION
## Your Project or User Demand

Ran the full `DOGFOODING.md` runbook (all 21 scenarios, D/L/E/B/A/T) against `master` on a fresh Linux container to validate the current DX. Both fixes here are blockers I hit while doing that — the same working mode as #254 and #241.

## User Story

**1. `L4` could not pass at all.** The lez-framework template is the flagship framework example, and its only state-mutating instruction never executes. After `lgs new --template lez-framework`, `setup`, `build`, `deploy`, calling `increment` submits fine but the sequencer drops it at the execution check:

```
InvalidProgramBehavior(ExecutionValidationFailed(MismatchedTotalBalance {
    total_balance_pre_states:  WrappedBalanceSum { lo: 0, hi: 0 },
    total_balance_post_states: WrappedBalanceSum { lo: 7, hi: 0 },
}))
```

The guest did `counter.account.balance += amount`, i.e. minted balance. LEZ enforces conservation of total balance across a transaction, so this can never succeed. Submission exits 0, so it only shows up in the sequencer log and in an account whose data never changes — exactly the "a successful deploy means nothing if the runner cannot interact with the program" case `DOGFOODING.md` calls out.

**2. `LOGOS_SCAFFOLD_CACHE_ROOT` was silently ignored at creation.** I set it to isolate my run from a shared cache. Every command *inside* the project honored it (`doctor` printed `cache root | <dir> (from LOGOS_SCAFFOLD_CACHE_ROOT)`), but `new` had already cloned the pinned LEZ into `$HOME/.cache/logos-scaffold`. Result: the ~1.1 GB LEZ checkout cloned twice, and a `doctor` line naming a root that creation never used. `--cache-root` worked, so the flag and the env var disagreed.

## Change Summary

Extracts the creation-time cache-root precedence into `bootstrap_cache_root` (`--cache-root` → `LOGOS_SCAFFOLD_CACHE_ROOT` → platform default), placed next to `resolve_cache_root` so the two chains are visibly the same minus the `scaffold.toml` layer. Moves the lez-framework counter from `account.balance` into `account.data` as a little-endian `u64`, seeded to zero on `initialize`.

## Verification

- **L1, L2, L3, L4** rerun on a generated `lez-framework` project against a real localnet. After the fix `initialize` + `increment(7)` both commit with no execution-check errors, the counter PDA reads `data: "0700000000000000"` (= 7) with `balance: 0`, and a second `increment(5)` accumulates to 12. Driven through the generated client in `src/generated/lez_counter_client.rs`.
- **D1, D2, E2** rerun for the cache-root change; verified all three layers: env honored by `new`, `--cache-root` still wins over env, and no env still falls back to the platform default.
- Tests: 3 added in `src/project.rs` covering the three `bootstrap_cache_root` layers. Full suite 779 passing, `cargo fmt --check` and `cargo check` clean.
- `template-e2e` covers `templates/**` on the `lez-framework` matrix leg, so the guest change is exercised by CI.

## Notes for reviewers

Two unrelated things this run surfaced that are **not** in this PR, to keep it scoped:

- `run_lez_counter` is still a stub (`// TODO: submit transaction via wallet`). Wiring it to the generated client needs a decision about ordering, since `src/generated/` does not exist until `build client` runs, which is after the workspace build. Happy to follow up if you say which way you want it.
- On the lez-framework template, a bare `cargo run --bin ...` fails in `ring` with `riscv32-unknown-elf-gcc: error: unrecognized command-line option '-m64'`: risc0-build sets unqualified `CC` to the RISC-V cross-gcc and cc-rs then uses it for a host build-script compile. `lgs build` is unaffected; `HOST_CC=/usr/bin/cc` works around it. Looks upstream.

## Checklist

- [x] CI is green
- [x] Relevant DOGFOODING scenarios rerun (listed above)
- [x] Docs updated if user-facing behavior changed — no user-facing surface change; both are defect fixes to documented behavior
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and this PR fits within the weekly contribution cap