### PR TITLE
fix(localnet): make [localnet].port actually take effect

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -351,6 +351,8 @@ fn start_localnet(
     sequencer_cmd
         .current_dir(lez)
         .arg(&patched_config_path)
+        .arg("--port")
+        .arg(localnet_port.to_string())
         .env("RUST_LOG", "info")
         .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" });
 
@@ -693,8 +695,14 @@ fn build_status_report(
 /// Produce a sequencer config patched for scaffold's localnet — port set to
 /// the project's configured port and `max_block_size` widened so the bundled
 /// deploy flow fits in a single block — and return the absolute path to the
-/// patched file. The pinned LEZ version does not accept `--port` as a CLI flag
-/// — it reads everything from the config file passed as its first argument.
+/// patched file.
+///
+/// The pinned sequencer binary ignores this file's `port` key for RPC
+/// binding: it always binds the `--port` CLI flag (clap default `3040`),
+/// which `start_localnet` also passes explicitly so it matches this
+/// patched config's port. The `port` key is still written here for any
+/// tooling that inspects the config file directly, and so the file stays
+/// internally consistent with the port the sequencer is actually bound to.
 ///
 /// The patched copy is written under `dest_dir` (the project's
 /// `.scaffold/state/`), **not** back into the vendored LEZ checkout. Writing

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -20,7 +20,9 @@ use crate::commands::run_state::{
 };
 use crate::commands::setup::ensure_default_wallet_seeded;
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
-use crate::commands::wallet_support::set_wallet_home_env;
+use crate::commands::wallet_support::{
+    default_sequencer_http_url_for_project, set_wallet_home_env,
+};
 use crate::constants::{
     DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, FRAMEWORK_KIND_LEZ_FRAMEWORK, SPEL_BIN_REL_PATH,
     WALLET_BIN_REL_PATH,
@@ -548,7 +550,11 @@ fn segment_match(pat: &[u8], seg: &[u8]) -> bool {
 fn reseed_after_wipe(project: &Project) -> DynResult<()> {
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let wallet_home = project.root.join(&project.config.wallet_home_dir);
-    prepare_wallet_home(&lez, &wallet_home)?;
+    prepare_wallet_home(
+        &lez,
+        &wallet_home,
+        &default_sequencer_http_url_for_project(project),
+    )?;
     ensure_default_wallet_seeded(&project.root, &wallet_home, &lez.join(WALLET_BIN_REL_PATH))
 }
 
@@ -1708,7 +1714,10 @@ mod tests {
         {
             let lez = baseline.path().join("lez");
             let wallet_home = baseline.path().join(".scaffold/wallet");
-            prepare_wallet_home(&lez, &wallet_home).expect("baseline prepare");
+            // Matches make_test_project's default localnet.port (3040) below,
+            // so this stays byte-equivalent to the post-reset path.
+            prepare_wallet_home(&lez, &wallet_home, "http://127.0.0.1:3040")
+                .expect("baseline prepare");
             ensure_default_wallet_seeded(
                 baseline.path(),
                 &wallet_home,

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -11,9 +11,9 @@ use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
 use super::wallet_support::{
-    first_public_address_in_listing, first_public_wallet_address, read_default_wallet_address,
-    set_wallet_home_env, summarize_command_failure, wallet_password, wallet_state_path,
-    write_default_wallet_address,
+    default_sequencer_http_url_for_project, first_public_address_in_listing,
+    first_public_wallet_address, read_default_wallet_address, set_wallet_home_env,
+    summarize_command_failure, wallet_password, wallet_state_path, write_default_wallet_address,
 };
 
 /// Cargo args for the standalone sequencer build. `--features standalone`
@@ -96,7 +96,11 @@ pub(crate) fn setup_for_project(project: &crate::model::Project, prebuilt: bool)
     )?;
 
     let wallet_home = project.root.join(&project.config.wallet_home_dir);
-    prepare_wallet_home(&lez, &wallet_home)?;
+    prepare_wallet_home(
+        &lez,
+        &wallet_home,
+        &default_sequencer_http_url_for_project(project),
+    )?;
     ensure_default_wallet_seeded(&project.root, &wallet_home, &lez.join(WALLET_BIN_REL_PATH))?;
 
     println!("setup complete");

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::constants::WALLET_CONFIG_REL_PATHS;
@@ -127,13 +127,40 @@ pub(crate) fn read_basecamp_state(path: &Path) -> DynResult<BasecampState> {
     Ok(state)
 }
 
-pub(crate) fn prepare_wallet_home(lez_repo: &Path, wallet_home: &Path) -> DynResult<()> {
+/// Seed a fresh wallet home from the vendored LEZ debug wallet config, if
+/// one doesn't already exist there.
+///
+/// `sequencer_addr` overrides the vendored config's hardcoded value (the
+/// LEZ debug fixture ships `http://127.0.0.1:3040`) with the address this
+/// project's sequencer actually binds to, so the wallet follows
+/// `[localnet].port` instead of silently pointing at 3040 regardless of
+/// what the project is configured to use. Pass
+/// `default_sequencer_http_url_for_project(project)`.
+pub(crate) fn prepare_wallet_home(
+    lez_repo: &Path,
+    wallet_home: &Path,
+    sequencer_addr: &str,
+) -> DynResult<()> {
     fs::create_dir_all(wallet_home)?;
     let cfg_dst = wallet_home.join(WALLET_CONFIG_PRIMARY);
     if !cfg_dst.exists() {
         let cfg_src =
             first_existing_lez_path(lez_repo, WALLET_CONFIG_REL_PATHS, "wallet debug config")?;
-        fs::copy(cfg_src, cfg_dst)?;
+        let text = fs::read_to_string(&cfg_src)
+            .with_context(|| format!("failed to read {}", cfg_src.display()))?;
+        let mut doc: serde_json::Value =
+            serde_json::from_str(&text).context("failed to parse wallet debug config")?;
+        let Some(obj) = doc.as_object_mut() else {
+            bail!(
+                "wallet debug config is not a JSON object: {}",
+                cfg_src.display()
+            );
+        };
+        obj.insert(
+            "sequencer_addr".to_string(),
+            serde_json::Value::String(sequencer_addr.to_string()),
+        );
+        fs::write(&cfg_dst, serde_json::to_string_pretty(&doc)?)?;
     }
     Ok(())
 }
@@ -211,10 +238,78 @@ mod tests {
         fs::create_dir_all(cfg_src.parent().unwrap()).expect("create nested wallet config dir");
         fs::write(&cfg_src, "{ \"network\": \"debug\" }\n").expect("write wallet config");
 
-        prepare_wallet_home(&lez, &wallet_home).expect("prepare wallet home");
+        prepare_wallet_home(&lez, &wallet_home, "http://127.0.0.1:5050")
+            .expect("prepare wallet home");
 
         let copied = fs::read_to_string(wallet_home.join(WALLET_CONFIG_PRIMARY))
             .expect("read copied wallet config");
-        assert_eq!(copied, "{ \"network\": \"debug\" }\n");
+        let copied: serde_json::Value = serde_json::from_str(&copied).expect("parse copied");
+        assert_eq!(copied["network"], "debug");
+        assert_eq!(copied["sequencer_addr"], "http://127.0.0.1:5050");
+    }
+
+    /// Regression for #263: the vendored LEZ debug wallet config hardcodes
+    /// `sequencer_addr: http://127.0.0.1:3040`. Without overriding it on
+    /// seeding, a project configured for a different `[localnet].port`
+    /// would silently get a wallet that talks to the wrong (or, when 3040
+    /// is occupied by another project, a nonexistent) sequencer.
+    #[test]
+    fn prepare_wallet_home_overrides_vendored_sequencer_addr() {
+        let tmp = tempdir().expect("tempdir");
+        let lez = tmp.path().join("lez");
+        let wallet_home = tmp.path().join("wallet-home");
+
+        let cfg_src = lez.join("wallet/configs/debug/wallet_config.json");
+        fs::create_dir_all(cfg_src.parent().unwrap()).expect("create wallet config dir");
+        fs::write(
+            &cfg_src,
+            r#"{ "sequencer_addr": "http://127.0.0.1:3040", "seq_poll_timeout": "30s" }"#,
+        )
+        .expect("write vendored wallet config");
+
+        prepare_wallet_home(&lez, &wallet_home, "http://127.0.0.1:4141")
+            .expect("prepare wallet home");
+
+        let copied = fs::read_to_string(wallet_home.join(WALLET_CONFIG_PRIMARY))
+            .expect("read copied wallet config");
+        let copied: serde_json::Value = serde_json::from_str(&copied).expect("parse copied");
+        assert_eq!(
+            copied["sequencer_addr"], "http://127.0.0.1:4141",
+            "expected the project's configured sequencer address to replace the vendored default, got: {copied}"
+        );
+        // Unrelated fields must survive untouched.
+        assert_eq!(copied["seq_poll_timeout"], "30s");
+    }
+
+    /// An already-seeded wallet home (e.g. a project whose wallet was set up
+    /// before, and whose localnet port later changed) must not be silently
+    /// rewritten — `prepare_wallet_home` only seeds a fresh wallet home.
+    #[test]
+    fn prepare_wallet_home_does_not_touch_existing_wallet_config() {
+        let tmp = tempdir().expect("tempdir");
+        let lez = tmp.path().join("lez");
+        let wallet_home = tmp.path().join("wallet-home");
+
+        let cfg_src = lez.join("wallet/configs/debug/wallet_config.json");
+        fs::create_dir_all(cfg_src.parent().unwrap()).expect("create wallet config dir");
+        fs::write(&cfg_src, r#"{ "sequencer_addr": "http://127.0.0.1:3040" }"#)
+            .expect("write vendored wallet config");
+
+        fs::create_dir_all(&wallet_home).expect("create wallet home");
+        let existing = wallet_home.join(WALLET_CONFIG_PRIMARY);
+        fs::write(
+            &existing,
+            r#"{ "sequencer_addr": "http://127.0.0.1:9999" }"#,
+        )
+        .expect("write pre-existing wallet config");
+
+        prepare_wallet_home(&lez, &wallet_home, "http://127.0.0.1:4141")
+            .expect("prepare wallet home");
+
+        let unchanged = fs::read_to_string(&existing).expect("read wallet config");
+        assert_eq!(
+            unchanged,
+            r#"{ "sequencer_addr": "http://127.0.0.1:9999" }"#
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1107,12 +1107,13 @@ fn localnet_start_patches_config_and_uses_configured_port() {
     fs::create_dir_all(config_path.parent().expect("parent")).expect("create config dir");
     fs::write(&config_path, r#"{"port": 3040}"#).expect("write sequencer config");
 
-    // Fake sequencer: reads port from sequencer_config.json (like the real one),
-    // logs args and env for assertions.
+    // Fake sequencer: binds the `--port` CLI flag, like the real pinned
+    // sequencer_service does (it ignores sequencer_config.json's `port` key
+    // entirely for RPC binding — see #263). Logs args and env for assertions.
     fs::write(
         &sequencer_bin,
         format!(
-            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > '{}'\nprintf '%s' \"${{RISC0_DEV_MODE:-}}\" > '{}'\nport=$(python3 -c \"import json,sys; print(json.load(open(sys.argv[1]))['port'])\" \"$1\")\nexec python3 -m http.server \"$port\" --bind 127.0.0.1\n",
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > '{}'\nprintf '%s' \"${{RISC0_DEV_MODE:-}}\" > '{}'\nport=\"$3\"\nexec python3 -m http.server \"$port\" --bind 127.0.0.1\n",
             args_log.display(),
             env_log.display(),
         ),
@@ -1193,10 +1194,16 @@ fn localnet_start_patches_config_and_uses_configured_port() {
         patched_path.display()
     );
 
-    // Verify --port was NOT passed as a CLI arg
+    // Regression for #263: the pinned sequencer binds `--port`, not the
+    // config file's `port` key, so `localnet start` must pass it explicitly
+    // — matching the value patched into the config, so both stay consistent.
     assert!(
-        !args.contains("--port"),
-        "expected --port NOT to appear in sequencer args, got: {args}"
+        args.lines().any(|line| line == "--port"),
+        "expected --port to appear in sequencer args, got: {args}"
+    );
+    assert!(
+        args.lines().any(|line| line == localnet_port.to_string()),
+        "expected --port {localnet_port} to appear in sequencer args, got: {args}"
     );
 
     let env = fs::read_to_string(&env_log).expect("read env log");


### PR DESCRIPTION
Fixes #263.

`[localnet].port` in `scaffold.toml` did nothing — two bugs canceled out in opposite directions.

**Sequencer side**: the pinned `sequencer_service` binds the port given by its `--port` CLI flag (clap default `3040`) — confirmed by reading `sequencer/service/src/main.rs` and `lib.rs::run()` directly at the pinned SHA (`logos-execution-zone` @ `cf3639d8`). It never reads the `sequencer_config.json` `port` key that `prepare_sequencer_config` patches for this purpose. `start_localnet` never passed `--port`, so the sequencer always bound `3040` regardless of the configured port. (`test_node` already does this correctly — a separate code path.)

**Wallet side**: `prepare_wallet_home` seeds a fresh wallet home by copying the vendored LEZ debug `wallet_config.json` verbatim. That file hardcodes `sequencer_addr: http://127.0.0.1:3040`. Since the key is present, `load_wallet_runtime`'s fallback to `default_sequencer_http_url_for_project` (which does follow `[localnet].port`) never triggers.

As the issue notes, fixing only one side breaks the other — moving the sequencer without fixing the wallet breaks `deploy` with `Connection refused`. This PR does both:
- `start_localnet` now passes `--port <configured>`, mirroring `test_node`'s existing pattern.
- `prepare_wallet_home` now takes the project's configured sequencer address and writes it into the freshly-seeded wallet config, instead of leaving the vendored `3040` default.
- Fixed a stale doc comment on `prepare_sequencer_config` that incorrectly claimed the pinned sequencer doesn't accept `--port`.

`tests/cli.rs::localnet_start_patches_config_and_uses_configured_port` previously locked in the old behavior (asserted `--port` must **not** be passed, per the issue's own note); inverted here, with the fake sequencer now binding `--port` like the real one. Added two regression tests for the wallet-seeding half in `state.rs`.

- Full suite: 587/587 lib tests pass, 186/186 cli integration tests pass.
- No behavior change when `[localnet].port` is left at the default `3040`.